### PR TITLE
Better verse overflow handling

### DIFF
--- a/src/helpers/response_builder.rs
+++ b/src/helpers/response_builder.rs
@@ -50,8 +50,6 @@ impl ResponseBuilder {
         let scripture_full = format!("{} - {}", scriptures, scripture_reference);
 
         if scripture_full.len() > total_length {
-            // -18 is for having " !next to continue" included in the message if the verse gets cut
-            // off
             let adjusted_length = total_length - scripture_reference_abbreviation.len();
             let mut scripture = String::new();
             let mut last_verse = verses.last().unwrap();
@@ -71,7 +69,6 @@ impl ResponseBuilder {
                 .map(|(idx, _)| idx)
                 .last()
                 .unwrap_or(adjusted_length);
-            // reused code here to make shortened scripture_reference_abbreviation accurate
             let scripture_reference_abbreviation = if start_verse == end_verse {
                 format!("{}:{} {}", abbreviation, start_verse, bible_name_to_use)
             } else {

--- a/src/helpers/response_builder.rs
+++ b/src/helpers/response_builder.rs
@@ -52,7 +52,7 @@ impl ResponseBuilder {
         if scripture_full.len() > total_length {
             // -18 is for having " !next to continue" included in the message if the verse gets cut
             // off
-            let adjusted_length = total_length - scripture_reference_abbreviation.len() - 18;
+            let adjusted_length = total_length - scripture_reference_abbreviation.len();
             let mut scripture = String::new();
             let mut last_verse = verses.last().unwrap();
             for verse in verses {
@@ -83,7 +83,7 @@ impl ResponseBuilder {
 
             ResponseOutput {
                 truncated: format!(
-                    "{} - {} !next to continue",
+                    "{} - {}",
                     scripture,
                     scripture_reference_abbreviation
                 ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,7 @@ async fn handle_twitch_messages(mut listener_reciever: mpsc::UnboundedReceiver<M
                                                 adjusted_character_limit,
                                                 &bible_name_to_use,
                                             );
-                                            config.set_last_verse(&verses.last().unwrap().reference);
+                                            config.set_last_verse(&response_output.last_verse);
                                             config.add_account_metrics_scriptures();
 
                                             if !channel.eq_ignore_ascii_case(display_name) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8ffbeb04-93c1-45e6-a324-f35c18e81ea6)
Here is an example with this change and prod running side by side, as you can see prod cuts off a verse and the !next command skips a ton of verses, the changes here would back off if the verse would be cut off and set the !next command to use the next verse.